### PR TITLE
Feature/mvn38

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-ARG BASE=centos:stream8
+ARG BASE=fedora:37
 FROM $BASE
 
-RUN yum module enable -y maven:3.8 nodejs:16 \
+RUN yum module enable -y nodejs:16 \
     && yum update -y \
     && yum install -y --nobest \
        ca-certificates \
@@ -37,7 +37,7 @@ ENV JAVA_HOME=/usr/lib/jvm/jre-11 \
     JAVA_HOME_11_X64=/usr/lib/jvm/jre-11 \
     JAVA_HOME_17_X64=/usr/lib/jvm/jre-17 \
     NODE_EXTRA_CA_CERTS=/etc/pki/ca-trust/source/anchors/internal.crt 
-
+    
 # Can be 'linux-x64', 'linux-arm64', 'linux-arm', 'rhel.6-x64'.
 ENV TARGETARCH=linux-x64
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE=centos:stream8
 FROM $BASE
 
-RUN yum module enable -y maven:3.6 nodejs:16 \
+RUN yum module enable -y maven:3.8 nodejs:16 \
     && yum update -y \
     && yum install -y --nobest \
        ca-certificates \
@@ -33,18 +33,15 @@ RUN update-ca-trust force-enable \
     && update-ca-trust extract \
     && rm -rf /tmp/ca
 
-ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk \
-    JAVA_HOME_11_X64=/usr/lib/jvm/java-11-openjdk \
-    JAVA_HOME_17_X64=/usr/lib/jvm/java-17-openjdk \
+ENV JAVA_HOME=/usr/lib/jvm/jre-11 \
+    JAVA_HOME_11_X64=/usr/lib/jvm/jre-11 \
+    JAVA_HOME_17_X64=/usr/lib/jvm/jre-17 \
     NODE_EXTRA_CA_CERTS=/etc/pki/ca-trust/source/anchors/internal.crt 
 
 # Can be 'linux-x64', 'linux-arm64', 'linux-arm', 'rhel.6-x64'.
 ENV TARGETARCH=linux-x64
 
 WORKDIR /azp
-
-# RHEL8's /etc/java/maven.conf hardcoded sets JAVA_HOME to openjdk 11 preventing overruling jdkVersion in Maven task
-RUN echo '[[ ! -z "${JAVA_HOME}" ]] || JAVA_HOME=/usr/lib/jvm/java-11-openjdk' > /etc/java/maven.conf
 
 COPY ./start.sh .
 RUN chmod +x start.sh

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ OpenShift manifests and instructions for running Azure Agent on OpenShift
 - ephermal agent runs a single job and then exits using --once
 - Node.js & NPM (16)
 - DotNet SDK 6.0
-- Java 11/17 & Maven 3.6
+- Java 11/17 & Maven 3.8
 - Python 3.9
 
 ## Create azure-repos pull secret

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ OpenShift manifests and instructions for running Azure Agent on OpenShift
 
 ## Customisations
 
-- Based on Centos:stream8 with findutils and (un)zip
+- Based on fedora:37 with findutils and (un)zip
 - Automatic cleanup of agents on container exit
 - ephermal agent runs a single job and then exits using --once
 - Node.js & NPM (16)
@@ -25,9 +25,9 @@ The build template expects a source secret available on the Openshift namespace 
 
 ## Create imagestream
 
-Openshift expects an imagestream called Centos:stream8 as basis to build the agent based on these templates
+Openshift expects an imagestream called fedora:36 as basis to build the agent based on these templates
 This can be added to your imagestream with:  
-```oc import-image centos:stream8 --confirm```
+```oc import-image fedora:37 --confirm```
 
 # Azure Agent Deployment
 
@@ -35,6 +35,7 @@ The included build script for Azure DevOps expects three variables to be defined
 * AZP_POOL : The Agent pool in which the agents are going to run
 * AZP_URL : The URL to the Azure DevOps organisation (cloud) or collection (on-premise)
 * AZP_TOKEN : A PAT token with sufficient permissions. This is only the **Agent Pools** > **Read & Manage** permission
+* AZP_AGENT_PACKAGE_LATEST_URL: The v3 pre-release agent download URL (Fedora:37 contains OpelSSL 3, incompatble with the current v2 agent). If the v3 agent is released this variable becomes optional again
 
 ## Scale agents
 

--- a/build/build-pipeline.yml
+++ b/build/build-pipeline.yml
@@ -55,7 +55,7 @@ jobs:
   - task: CmdLine@2
     displayName: Process config template
     inputs:
-      script: 'oc process -f $(System.DefaultWorkingDirectory)/$(ConfigTemplatePath) --local -p APPLICATIONNAME=$(ApplicationName) -p AZP_URL=$(AZP_URL) -p AZP_POOL=$(AZP_POOL) -o=yaml > config-template.yaml'
+      script: 'oc process -f $(System.DefaultWorkingDirectory)/$(ConfigTemplatePath) --local -p APPLICATIONNAME=$(ApplicationName) -p AZP_URL=$(AZP_URL) -p AZP_POOL=$(AZP_POOL) -p AZP_AGENT_PACKAGE_LATEST_URL=$(AZP_AGENT_PACKAGE_LATEST_URL) -o=yaml > config-template.yaml'
 
   - task: oc-cmd@2
     displayName: Apply config template DCR1

--- a/manifests/azure-agent-buildconfig.yaml
+++ b/manifests/azure-agent-buildconfig.yaml
@@ -63,5 +63,5 @@ objects:
 #            value: .company.internal.net
         from:
           kind: ImageStreamTag
-          name: centos:stream8
+          name: fedora:37
       type: Docker

--- a/manifests/azure-agent-configmap.yaml
+++ b/manifests/azure-agent-configmap.yaml
@@ -19,12 +19,16 @@ parameters:
 - description: Capablitities
   name: AZP_CAPABILITY_ENV_VARS
   value: ""
+- description: Agent download url
+  name: AZP_AGENT_PACKAGE_LATEST_URL
+  value: ""
 objects:
 - apiVersion: v1
   data:
     AZP_URL: ${AZP_URL}
     AZP_POOL: ${AZP_POOL}
     AZP_CAPABILITY_ENV_VARS: ${AZP_CAPABILITY_ENV_VARS}
+    AZP_AGENT_PACKAGE_LATEST_URL: ${AZP_AGENT_PACKAGE_LATEST_URL}
   kind: ConfigMap
   metadata:
     name: ${APPLICATIONNAME}

--- a/manifests/azure-agent-deploymentconfig.yaml
+++ b/manifests/azure-agent-deploymentconfig.yaml
@@ -65,6 +65,11 @@ objects:
               configMapKeyRef:
                 key: AZP_CAPABILITY_ENV_VARS
                 name: ${APPLICATIONNAME}
+          - name: AZP_AGENT_PACKAGE_LATEST_URL
+            valueFrom:
+              configMapKeyRef:
+                key: AZP_AGENT_PACKAGE_LATEST_URL
+                name: ${APPLICATIONNAME}
           image: ${APPLICATIONNAME}:latest
           args:
             - '--once'


### PR DESCRIPTION
RHEL8 on prem biedt maven 3.8 (en daar was veel behoefte aan), ubi8-minimal en centos:stream8 gaan niet verder als maven 3.6 maar AlmaLinux 8.7 en Fedora 37 bieden wel de 3.8 versie. Helaas staat AlmaLinux niet op de v3 whitelist (dus geeft een warning bij elke job) en is Fedora 37 een OpenSSL 3 distro waardoor alleen v3 agents het doen. start.sh kon al overweg met een hardcoded agent download url (AZP_AGENT_PACKAGE_LATEST_URL) dus heb ik die hier gebruikt om een v3 pre-release agent download mee te forceren.